### PR TITLE
added custom permission to session request detail view

### DIFF
--- a/team_production_system/custom_permissions.py
+++ b/team_production_system/custom_permissions.py
@@ -1,0 +1,6 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsMentorMentee(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        return request.user.pk == obj.mentor.pk or request.user.pk == obj.mentee.pk

--- a/team_production_system/views.py
+++ b/team_production_system/views.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from django.utils import timezone
 from rest_framework.permissions import IsAuthenticated
 from django.db.models import Q
+from .custom_permissions import IsMentorMentee
 
 
 from rest_framework.parsers import MultiPartParser
@@ -206,7 +207,7 @@ class SessionRequestView(generics.ListCreateAPIView):
 class SessionRequestDetailView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Session.objects.all()
     serializer_class = SessionSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsMentorMentee]
 
     # Update the session status
     def perform_update(self, serializer):


### PR DESCRIPTION
I added a custom permission to the SessionRequestDetailView so that only the mentee or mentor of the session can access that endpoint. Tested locally via Insomnia.