### PR TITLE
fix: usernames are saved to database as lowercase

### DIFF
--- a/team_production_system/models.py
+++ b/team_production_system/models.py
@@ -29,7 +29,7 @@ class CustomUser(AbstractUser):
     def save(self, *args, **kwargs):
         # Check if user is a new user
         is_new_user = self.pk is None
-
+        self.username = self.username.lower()
         super().save(*args, **kwargs)
 
         if is_new_user:


### PR DESCRIPTION
fix: usernames are saved to database as lowercase

Here is how it was tested: 

Sent username with uppercase letter, returns it lowercase
<img width="1145" alt="Screen Shot 2023-06-06 at 3 48 05 PM" src="https://github.com/TeamProductionSystem/Team_Production_System_BE/assets/14296669/1b4c0de3-6bf4-46f5-bede-ba5bc58a9e45">

In database it shows it saved as lowercase
<img width="1103" alt="Screen Shot 2023-06-06 at 3 48 23 PM" src="https://github.com/TeamProductionSystem/Team_Production_System_BE/assets/14296669/0a853b39-ef07-4f0a-b83f-55e93a954407">


