### PR TITLE
Availability date overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please adhere to this project's [code of conduct](https://github.com/TeamProduct
 - Users can setup profiles as a mentor or mentee.
 - Mentors can set their skill set and avalibilty.
 - Mentees can schedule sessions with the menots, filtered by skills and avalibilty
-- Menotrs can confirm sessions
+- Mentors can confirm sessions
 - Both mentor and mentee can cancel a session prior to session start time.
 
 # Run Locally

--- a/team_production_system/serializers.py
+++ b/team_production_system/serializers.py
@@ -38,7 +38,6 @@ class AvailabilitySerializer(serializers.ModelSerializer):
         end_time = self.data['end_time']
         overlapping_start = Availability.objects.filter(
             mentor=mentor,
-            #EndA <= StartB or StartA >= EndB
             start_time__lte=end_time,
             start_time__gte=start_time).count()
         overlapping_end = Availability.objects.filter(

--- a/team_production_system/serializers.py
+++ b/team_production_system/serializers.py
@@ -43,7 +43,7 @@ class AvailabilitySerializer(serializers.ModelSerializer):
         overlapping_end = Availability.objects.filter(
             mentor=mentor,
             end_time__gte=start_time,
-            end_time__lte=end_time).count())
+            end_time__lte=end_time).count()
         availability_overlap = overlapping_start > 0 or overlapping_end > 0
         if availability_overlap == False:
             availability = Availability.objects.create(

--- a/team_production_system/serializers.py
+++ b/team_production_system/serializers.py
@@ -43,8 +43,7 @@ class AvailabilitySerializer(serializers.ModelSerializer):
         overlapping_end = Availability.objects.filter(
             mentor=mentor,
             end_time__gte=start_time,
-            end_time__lte=end_time).count()
-        breakpoint()
+            end_time__lte=end_time).count())
         availability_overlap = overlapping_start > 0 or overlapping_end > 0
         if availability_overlap == False:
             availability = Availability.objects.create(

--- a/team_production_system/serializers.py
+++ b/team_production_system/serializers.py
@@ -37,11 +37,15 @@ class AvailabilitySerializer(serializers.ModelSerializer):
         start_time = self.data['start_time']
         end_time = self.data['end_time']
         overlapping_start = Availability.objects.filter(
-            start_time__gte=start_time, 
-            start_time__lte=start_time).count()
+            mentor=mentor,
+            #EndA <= StartB or StartA >= EndB
+            start_time__lte=end_time,
+            start_time__gte=start_time).count()
         overlapping_end = Availability.objects.filter(
-            end_time__gte=end_time, 
+            mentor=mentor,
+            end_time__gte=start_time,
             end_time__lte=end_time).count()
+        breakpoint()
         availability_overlap = overlapping_start > 0 or overlapping_end > 0
         if availability_overlap == False:
             availability = Availability.objects.create(


### PR DESCRIPTION
### **1. Targeted Issue** ###
[https://trello.com/c/xmz8NVxK](https://trello.com/c/xmz8NVxK)

Ticket #72

### **2. Overview of Solution** ###

I added a check in the create function of the Availability serializer. It checks to see if there is an overlapping start or end datetime with what is in the database. If date has time that already exists, the front end is sent an error message. 

Additional changes: small typo fix in README.md

### **3. Tools Used** ###

I used DRF Serializers to implement validation of the datetime overlap.

### **4. Testing Strategy** ###
I tested for the following cases:

- Mentor signs up for time when there is no availability overlap. New availability is created.
<img width="478" alt="Screen Shot 2023-06-21 at 11 28 36 AM" src="https://github.com/TeamProductionSystem/Team_Production_System_BE/assets/14296669/1c2e1b1e-6c05-44e6-a3d1-523d2bc1fdaa">

- Mentor signs up for a time that overlaps the end time of an already existing availability. Error message sent to front end, availability not created.
<img width="578" alt="Screen Shot 2023-06-21 at 11 28 52 AM" src="https://github.com/TeamProductionSystem/Team_Production_System_BE/assets/14296669/58538869-0de5-4850-a812-d763b7047bb5">

- Mentor signs up for a time that overlaps the start time of an already existing availability. Error message sent to front end, availability not created.
<img width="526" alt="Screen Shot 2023-06-21 at 11 29 06 AM" src="https://github.com/TeamProductionSystem/Team_Production_System_BE/assets/14296669/966909b6-6c62-42bb-a325-5e4468276d3f">

- Mentor signs up for a time that overlaps time across a day of an existing availability. Error message sent to front end, availability not created.
<img width="650" alt="Screen Shot 2023-06-21 at 11 29 20 AM" src="https://github.com/TeamProductionSystem/Team_Production_System_BE/assets/14296669/ad13151a-bc1f-4b2d-9821-934300898c80">

- A second mentor schedules a time for the same availability as the first. New availability is created.
<img width="571" alt="Screen Shot 2023-06-21 at 11 31 29 AM" src="https://github.com/TeamProductionSystem/Team_Production_System_BE/assets/14296669/44349d38-4e0c-4c81-b46a-5ff38340d9ca">

- Mentor schedules the exact same time twice. Gets current unique constriant error. 
<img width="559" alt="Screen Shot 2023-06-21 at 11 55 35 AM" src="https://github.com/TeamProductionSystem/Team_Production_System_BE/assets/14296669/48eb11f4-b42d-4508-b23e-b068ed806aaf">


### **5. Future Implications** ###

**A few things I noticed:** 

- Currently users can sign up for multi day availabilities, even more than a year. It would be good to scope out what seems like a reasonable amount of time to allow them to enter and validate it. I would suggest no longer than a 24 hr period right now since most folks are within 3-4 timezones of each other.

- There needs to be better error handling for the IntegrityError of the unique constraint on Availabilities in the backend. Perhaps replace it with a validation check in the serializer. 

### **6. Screenshots** ###
See testing

### **7. Code Reviewers** ###
I have talked to @GitLukeW about the implementation and results.


---

Before you go...

- [x]  I have linked the relevant issue
- [x]  I have provided an overview of my solution
- [x]  I have shared the tools I've used
- [x]  I have outlined my testing strategy
- [x]  I have considered future implications of my changes
- [x]  I have included relevant screenshots
- [x]  I have kept my team in the loop
