### PR TITLE
Updated confirmation emails to use the same jitsi meeting for mentors…

### DIFF
--- a/team_production_system/models.py
+++ b/team_production_system/models.py
@@ -181,7 +181,7 @@ class Session(models.Model):
         return f'https://meet.jit.si/{code}'
 
     # Notify the mentee and when the requested session has been confirmed
-    def mentee_confirm_notify(self):
+    def mentee_confirm_notify(self, meeting_link):
         # Define the timezone
         est = pytz.timezone('US/Eastern')
 
@@ -194,13 +194,13 @@ class Session(models.Model):
 
         send_mail(
             subject=('Mentor Session Confirmed'),
-            message=(f'A session with {self.mentee.user.first_name} and {self.mentor.user.first_name} has been confirmed for a {self.session_length}-minute mentoring session at {session_time} EST on {session_date}. Here is the link to your session: {self.create_meeting_link()}'),
+            message=(f'A session with {self.mentee.user.first_name} and {self.mentor.user.first_name} has been confirmed for a {self.session_length}-minute mentoring session at {session_time} EST on {session_date}. Here is the link to your session: {meeting_link}'),
             from_email=settings.EMAIL_HOST_USER,
             recipient_list=[self.mentee.user.email]
         )
 
     # Notify the mentor when the requested session has been confirmed
-    def mentor_confirm_notify(self):
+    def mentor_confirm_notify(self, meeting_link):
         # Define the timezone
         est = pytz.timezone('US/Eastern')
 
@@ -213,7 +213,7 @@ class Session(models.Model):
 
         send_mail(
             subject=('Mentor Session Confirmed'),
-            message=(f'A session with {self.mentee.user.first_name} and {self.mentor.user.first_name} has been confirmed for a {self.session_length}-minute mentoring session at {session_time} EST on {session_date}. Here is the link to your session: {self.create_meeting_link()}'),
+            message=(f'A session with {self.mentee.user.first_name} and {self.mentor.user.first_name} has been confirmed for a {self.session_length}-minute mentoring session at {session_time} EST on {session_date}. Here is the link to your session: {meeting_link}'),
             from_email=settings.EMAIL_HOST_USER,
             recipient_list=[self.mentor.user.email]
         )

--- a/team_production_system/views.py
+++ b/team_production_system/views.py
@@ -329,15 +329,16 @@ class SessionRequestDetailView(generics.RetrieveUpdateDestroyAPIView):
         # Notify mentee when a mentor confirms session request
         elif status == 'Confirmed':
             session.status = status
+            meeting_link = session.create_meeting_link()
             session.save()
 
             # Check mentee's notification settings before notifying
             if session.mentee.user.notification_settings.session_confirmed:
-                session.mentee_confirm_notify()
+                session.mentee_confirm_notify(meeting_link)
 
             # Check mentor's notification settings before notifying
             if session.mentor.user.notification_settings.session_confirmed:
-                session.mentor_confirm_notify()
+                session.mentor_confirm_notify(meeting_link)
 
         else:
             serializer.save()


### PR DESCRIPTION
… and mentees

## **Pull Request Template**

### **1. Targeted Issue** ###

Confirmation emails were sending a different jitsi meeting to mentors and mentees.

Issue #90


### **2. Overview of Solution** ###

Instead of creating a meeting in models.py for the mentor/mentee emails, we moved it to views.py to create a single meeting. We called the create_meeting_link() function and passed that link into the functions to send each email.


### **3. Tools Used** ###

Python, Django


### **4. Testing Strategy** ###

Set up new session to check if both users got the same meeting invite


### **5. Future Implications** ###

n/a


### **6. Screenshots** ###

n/a


### **7. Code Reviewers** ###

@GitLukeW 


---

Before you go...

- [ ]  I have linked the relevant issue
- [ ]  I have provided an overview of my solution
- [ ]  I have shared the tools I've used
- [ ]  I have outlined my testing strategy
- [ ]  I have considered future implications of my changes
- [ ]  I have included relevant screenshots
- [ ]  I have kept my team in the loop

---

### Big high-fives for your incredible pull request! We're thrilled to have you as a contributor! Our team will dig into your proposed changes and give you some feedback or merge them if they're good to go. Your contributions mean the world to us!    
